### PR TITLE
Allow overriding of path to Makefile.pdlibbuilder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,8 @@ cyclone-meta.pd
 
 externalsdir = ../..
 
-include $(firstword $(wildcard Makefile.pdlibbuilder \
+PDLIBBUILDER_DIR=.
+include $(firstword $(wildcard $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder \
   $(externalsdir)/Makefile.pdlibbuilder))
 
 


### PR DESCRIPTION
if the user installs pd-lib-builder separately, they can just point the buildsystem to their installation, e.g. to get the latest and greatest features of pd-lib-builder.

e.g. on Debian systems do:

~~~sh
sudo apt-get install pd-lib-builder
make PDLIBBUILDER_DIR=/usr/share/pd-lib-builder/
~~~